### PR TITLE
Subscribe to `popstate` on first pull

### DIFF
--- a/dom/src/main/scala/fs2/dom/EventTargetHelpers.scala
+++ b/dom/src/main/scala/fs2/dom/EventTargetHelpers.scala
@@ -30,7 +30,7 @@ private[dom] object EventTargetHelpers {
 
   def listen[F[_], E <: Event](target: EventTarget, `type`: String)(implicit
       F: Async[F]
-  ): Stream[F, E] = {
+  ): Resource[F, Stream[F, E]] = {
     val setup = for {
       dispatcher <- Dispatcher.sequential[F]
       abort <- AbortController[F]
@@ -49,7 +49,7 @@ private[dom] object EventTargetHelpers {
       }
     } yield ch
 
-    Stream.resource(setup).flatMap(_.stream)
+    setup.map(_.stream)
   }
 
 }

--- a/dom/src/main/scala/fs2/dom/package.scala
+++ b/dom/src/main/scala/fs2/dom/package.scala
@@ -45,6 +45,12 @@ package object dom {
     stream.through(toReadableStream).compile.resource.lastOrError
 
   def events[F[_]: Async, E <: Event](target: EventTarget, `type`: String): Stream[F, E] =
+    Stream.resource(EventTargetHelpers.listen(target, `type`)).flatten
+
+  def eventsResource[F[_]: Async, E <: Event](
+      target: EventTarget,
+      `type`: String
+  ): Resource[F, Stream[F, E]] =
     EventTargetHelpers.listen(target, `type`)
 
 }


### PR DESCRIPTION
To ensure that we don't miss any changes between the current state and the next `popstate` event, we must subscribe to that event immediately on the first pull, before emitting the current state.