### PR TITLE
Refactor event listener to use `async` instead of `Dispatcher`

### DIFF
--- a/dom/src/main/scala/fs2/dom/EventTargetHelpers.scala
+++ b/dom/src/main/scala/fs2/dom/EventTargetHelpers.scala
@@ -31,7 +31,7 @@ private[dom] object EventTargetHelpers {
           val ctrl = new dom.AbortController
           target.addEventListener[E](
             `type`,
-            e => cb(Right(e)),
+            (e: E) => cb(Right(e)),
             new dom.EventListenerOptions {
               once = true
               signal = ctrl.signal

--- a/dom/src/main/scala/fs2/dom/History.scala
+++ b/dom/src/main/scala/fs2/dom/History.scala
@@ -52,9 +52,9 @@ object History {
 
       def state = new Signal[F, Option[S]] {
         def discrete =
-          Stream.resource(eventsResource[F, PopStateEvent](window, "popstate")).flatMap { events =>
-            Stream.eval(get) ++ events.evalMap(e => serializer.deserialize(e.state).map(Some(_)))
-          }
+          Stream.eval(get) ++
+            events[F, PopStateEvent](window, "popstate")
+              .evalMap(e => serializer.deserialize(e.state).map(Some(_)))
 
         def get = OptionT(F.delay(Option(window.history.state)))
           .semiflatMap(serializer.deserialize(_))

--- a/dom/src/main/scala/fs2/dom/History.scala
+++ b/dom/src/main/scala/fs2/dom/History.scala
@@ -19,6 +19,7 @@ package fs2.dom
 import cats.data.OptionT
 import cats.effect.kernel.Async
 import cats.effect.kernel.Ref
+import cats.effect.std.Queue
 import cats.syntax.all._
 import fs2.Stream
 import fs2.concurrent.Signal
@@ -51,10 +52,15 @@ object History {
     new History[F, S] {
 
       def state = new Signal[F, Option[S]] {
-        def discrete =
-          Stream.eval(get) ++
-            events[F, PopStateEvent](window, "popstate")
-              .evalMap(e => serializer.deserialize(e.state).map(Some(_)))
+        def discrete = Stream.eval(Queue.circularBuffer[F, PopStateEvent](1)).flatMap { queue =>
+          val head = Stream.eval(get)
+          val tail =
+            Stream.repeatEval(queue.take).evalMap(e => serializer.deserialize(e.state).map(Some(_)))
+
+          val listener = events[F, PopStateEvent](window, "popstate").foreach(queue.offer(_))
+
+          (head ++ tail).concurrently(listener)
+        }
 
         def get = OptionT(F.delay(Option(window.history.state)))
           .semiflatMap(serializer.deserialize(_))

--- a/dom/src/main/scala/fs2/dom/package.scala
+++ b/dom/src/main/scala/fs2/dom/package.scala
@@ -45,12 +45,12 @@ package object dom {
     stream.through(toReadableStream).compile.resource.lastOrError
 
   def events[F[_]: Async, E <: Event](target: EventTarget, `type`: String): Stream[F, E] =
-    Stream.resource(EventTargetHelpers.listen(target, `type`)).flatten
+    EventTargetHelpers.listen(target, `type`)
 
+  @deprecated("Use events", "0.1.1")
   def eventsResource[F[_]: Async, E <: Event](
       target: EventTarget,
       `type`: String
-  ): Resource[F, Stream[F, E]] =
-    EventTargetHelpers.listen(target, `type`)
+  ): Resource[F, Stream[F, E]] = Resource.pure(events(target, `type`))
 
 }

--- a/testsBrowser/src/test/scala/fs2/dom/HistorySuite.scala
+++ b/testsBrowser/src/test/scala/fs2/dom/HistorySuite.scala
@@ -21,7 +21,6 @@ import fs2.concurrent.Channel
 import munit.CatsEffectSuite
 
 import scala.concurrent.duration._
-import scala.scalajs.concurrent.QueueExecutionContext
 
 class HistorySuite extends CatsEffectSuite {
 
@@ -40,12 +39,13 @@ class HistorySuite extends CatsEffectSuite {
           _ <- history.state.get.assertEquals(Some(3))
           _ <- history.back
           _ <- history.state.get.assertEquals(Some(1))
+          _ <- IO.sleep(1.second) // before the next UI
           _ <- history.forward
           _ <- history.state.get.assertEquals(Some(3))
           _ <- ch.stream.take(2).compile.toList.assertEquals(List(1, 3))
         } yield ()
       }
-    }.evalOn(QueueExecutionContext.promises())
+    }
   }
 
 }

--- a/testsBrowser/src/test/scala/fs2/dom/HistorySuite.scala
+++ b/testsBrowser/src/test/scala/fs2/dom/HistorySuite.scala
@@ -21,6 +21,7 @@ import fs2.concurrent.Channel
 import munit.CatsEffectSuite
 
 import scala.concurrent.duration._
+import scala.scalajs.concurrent.QueueExecutionContext
 
 class HistorySuite extends CatsEffectSuite {
 
@@ -44,7 +45,7 @@ class HistorySuite extends CatsEffectSuite {
           _ <- ch.stream.take(2).compile.toList.assertEquals(List(1, 3))
         } yield ()
       }
-    }
+    }.evalOn(QueueExecutionContext.promises())
   }
 
 }


### PR DESCRIPTION
The hope is that this change will reduce the overhead to setup a listener.

This is a moderate change in semantics: events are no longer queued up unboundedly. Instead the downstream must pull to subscribe to the next event.