### PR TITLE
Introduce `PropRef`

### DIFF
--- a/dom/src/main/scala-3/fs2/dom/Dom.scala
+++ b/dom/src/main/scala-3/fs2/dom/Dom.scala
@@ -77,11 +77,7 @@ opaque type HtmlBodyElement[F[_]] <: HtmlElement[F] = dom.HTMLBodyElement
 opaque type HtmlButtonElement[F[_]] <: HtmlElement[F] = dom.HTMLButtonElement
 object HtmlButtonElement {
   extension [F[_]](button: HtmlButtonElement[F]) {
-    def value(using Dom[F]): Ref[F, String] =
-      new WrappedRef[F, String] {
-        def unsafeGet() = button.value
-        def unsafeSet(s: String) = button.value = s
-      }
+    def value(using Dom[F]): Ref[F, String] = new PropRef(button, "value")
   }
 }
 
@@ -103,17 +99,9 @@ opaque type HtmlImageElement[F[_]] <: HtmlElement[F] = dom.HTMLImageElement
 opaque type HtmlInputElement[F[_]] <: HtmlElement[F] = dom.HTMLInputElement
 object HtmlInputElement {
   extension [F[_]](input: HtmlInputElement[F]) {
-    def checked(using Dom[F]): Ref[F, Boolean] =
-      new WrappedRef[F, Boolean] {
-        def unsafeGet() = input.checked
-        def unsafeSet(b: Boolean) = input.checked = b
-      }
+    def checked(using Dom[F]): Ref[F, Boolean] = new PropRef(input, "checked")
 
-    def value(using Dom[F]): Ref[F, String] =
-      new WrappedRef[F, String] {
-        def unsafeGet() = input.value
-        def unsafeSet(s: String) = input.value = s
-      }
+    def value(using Dom[F]): Ref[F, String] = new PropRef(input, "value")
   }
 }
 
@@ -132,11 +120,7 @@ opaque type HtmlOptGroupElement[F[_]] <: HtmlElement[F] = dom.HTMLOptGroupElemen
 opaque type HtmlOptionElement[F[_]] <: HtmlElement[F] = dom.HTMLOptionElement
 object HtmlOptionElement {
   extension [F[_]](option: HtmlOptionElement[F]) {
-    def value(using Dom[F]): Ref[F, String] =
-      new WrappedRef[F, String] {
-        def unsafeGet() = option.value
-        def unsafeSet(s: String) = option.value = s
-      }
+    def value(using Dom[F]): Ref[F, String] = new PropRef(option, "value")
   }
 }
 
@@ -150,11 +134,7 @@ opaque type HtmlScriptElement[F[_]] <: HtmlElement[F] = dom.HTMLScriptElement
 opaque type HtmlSelectElement[F[_]] <: HtmlElement[F] = dom.HTMLSelectElement
 object HtmlSelectElement {
   extension [F[_]](select: HtmlSelectElement[F]) {
-    def value(using Dom[F]): Ref[F, String] =
-      new WrappedRef[F, String] {
-        def unsafeGet() = select.value
-        def unsafeSet(s: String) = select.value = s
-      }
+    def value(using Dom[F]): Ref[F, String] = new PropRef(select, "value")
   }
 }
 
@@ -171,11 +151,7 @@ opaque type HtmlTableSectionElement[F[_]] <: HtmlElement[F] = dom.HTMLTableSecti
 opaque type HtmlTextAreaElement[F[_]] <: HtmlElement[F] = dom.HTMLTextAreaElement
 object HtmlTextAreaElement {
   extension [F[_]](textArea: HtmlTextAreaElement[F]) {
-    def value(using Dom[F]): Ref[F, String] =
-      new WrappedRef[F, String] {
-        def unsafeGet() = textArea.value
-        def unsafeSet(s: String) = textArea.value = s
-      }
+    def value(using Dom[F]): Ref[F, String] = new PropRef(textArea, "value")
   }
 }
 

--- a/dom/src/main/scala/fs2/dom/History.scala
+++ b/dom/src/main/scala/fs2/dom/History.scala
@@ -75,11 +75,7 @@ object History {
         def continuous = Stream.repeatEval(get)
       }
 
-      def scrollRestoration = new WrappedRef[F, ScrollRestoration] {
-        def unsafeGet(): ScrollRestoration = window.history.scrollRestoration
-        def unsafeSet(sr: ScrollRestoration): Unit =
-          window.history.scrollRestoration = sr
-      }
+      def scrollRestoration = new PropRef(window.history, "scrollRestoration")
 
       def forward = asyncPopState(window.history.forward())
       def back = asyncPopState(window.history.back())

--- a/dom/src/main/scala/fs2/dom/Location.scala
+++ b/dom/src/main/scala/fs2/dom/Location.scala
@@ -56,45 +56,21 @@ object Location {
   private def apply[F[_]](location: dom.Location)(implicit F: Sync[F]): Location[F] =
     new Location[F] {
 
-      def href = new WrappedRef[F, String] {
-        def unsafeGet() = location.href
-        def unsafeSet(s: String): Unit = location.href = s
-      }
+      def href = new PropRef(location, "href")
 
-      def protocol = new WrappedRef[F, String] {
-        def unsafeGet() = location.protocol
-        def unsafeSet(s: String): Unit = location.protocol = s
-      }
+      def protocol = new PropRef(location, "protocol")
 
-      def host = new WrappedRef[F, String] {
-        def unsafeGet() = location.host
-        def unsafeSet(s: String): Unit = location.host = s
-      }
+      def host = new PropRef(location, "host")
 
-      def hostname = new WrappedRef[F, String] {
-        def unsafeGet() = location.hostname
-        def unsafeSet(s: String): Unit = location.hostname = s
-      }
+      def hostname = new PropRef(location, "hostname")
 
-      def port = new WrappedRef[F, String] {
-        def unsafeGet() = location.port
-        def unsafeSet(s: String): Unit = location.port = s
-      }
+      def port = new PropRef(location, "port")
 
-      def pathname = new WrappedRef[F, String] {
-        def unsafeGet() = location.pathname
-        def unsafeSet(s: String): Unit = location.pathname = s
-      }
+      def pathname = new PropRef(location, "pathname")
 
-      def search = new WrappedRef[F, String] {
-        def unsafeGet() = location.search
-        def unsafeSet(s: String): Unit = location.search = s
-      }
+      def search = new PropRef(location, "search")
 
-      def hash = new WrappedRef[F, String] {
-        def unsafeGet() = location.hash
-        def unsafeSet(s: String): Unit = location.hash = s
-      }
+      def hash = new PropRef(location, "hash")
 
       def origin = F.delay(location.origin.asInstanceOf[String])
 

--- a/dom/src/main/scala/fs2/dom/PropRef.scala
+++ b/dom/src/main/scala/fs2/dom/PropRef.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022 Arman Bilge
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fs2.dom
+
+import cats.effect.kernel.Sync
+
+import scala.scalajs.js
+
+private[dom] final class PropRef[F[_], A](obj: Any, prop: String)(implicit F: Sync[F])
+    extends WrappedRef[F, A] {
+
+  def unsafeGet(): A =
+    obj.asInstanceOf[js.Dynamic].selectDynamic(prop).asInstanceOf[A]
+
+  def unsafeSet(a: A): Unit =
+    obj.asInstanceOf[js.Dynamic].updateDynamic(prop)(a.asInstanceOf[js.Any])
+
+}


### PR DESCRIPTION
A `WrappedRef` for the special case of setting/getting a property. This prevents a proliferation of anonymous subclasses, which is bad for code size.