### PR TITLE
Don't subclass `WrappedRef`

### DIFF
--- a/dom/src/main/scala-3/fs2/dom/Dom.scala
+++ b/dom/src/main/scala-3/fs2/dom/Dom.scala
@@ -78,10 +78,7 @@ opaque type HtmlButtonElement[F[_]] <: HtmlElement[F] = dom.HTMLButtonElement
 object HtmlButtonElement {
   extension [F[_]](button: HtmlButtonElement[F]) {
     def value(using Dom[F]): Ref[F, String] =
-      new WrappedRef[F, String] {
-        def unsafeGet() = button.value
-        def unsafeSet(s: String) = button.value = s
-      }
+      new WrappedRef(() => button.value, button.value = _)
   }
 }
 
@@ -104,16 +101,10 @@ opaque type HtmlInputElement[F[_]] <: HtmlElement[F] = dom.HTMLInputElement
 object HtmlInputElement {
   extension [F[_]](input: HtmlInputElement[F]) {
     def checked(using Dom[F]): Ref[F, Boolean] =
-      new WrappedRef[F, Boolean] {
-        def unsafeGet() = input.checked
-        def unsafeSet(b: Boolean) = input.checked = b
-      }
+      new WrappedRef(() => input.checked, input.checked = _)
 
     def value(using Dom[F]): Ref[F, String] =
-      new WrappedRef[F, String] {
-        def unsafeGet() = input.value
-        def unsafeSet(s: String) = input.value = s
-      }
+      new WrappedRef(() => input.value, input.value = _)
   }
 }
 
@@ -133,10 +124,7 @@ opaque type HtmlOptionElement[F[_]] <: HtmlElement[F] = dom.HTMLOptionElement
 object HtmlOptionElement {
   extension [F[_]](option: HtmlOptionElement[F]) {
     def value(using Dom[F]): Ref[F, String] =
-      new WrappedRef[F, String] {
-        def unsafeGet() = option.value
-        def unsafeSet(s: String) = option.value = s
-      }
+      new WrappedRef(() => option.value, option.value = _)
   }
 }
 
@@ -151,10 +139,7 @@ opaque type HtmlSelectElement[F[_]] <: HtmlElement[F] = dom.HTMLSelectElement
 object HtmlSelectElement {
   extension [F[_]](select: HtmlSelectElement[F]) {
     def value(using Dom[F]): Ref[F, String] =
-      new WrappedRef[F, String] {
-        def unsafeGet() = select.value
-        def unsafeSet(s: String) = select.value = s
-      }
+      new WrappedRef(() => select.value, select.value = _)
   }
 }
 
@@ -172,10 +157,7 @@ opaque type HtmlTextAreaElement[F[_]] <: HtmlElement[F] = dom.HTMLTextAreaElemen
 object HtmlTextAreaElement {
   extension [F[_]](textArea: HtmlTextAreaElement[F]) {
     def value(using Dom[F]): Ref[F, String] =
-      new WrappedRef[F, String] {
-        def unsafeGet() = textArea.value
-        def unsafeSet(s: String) = textArea.value = s
-      }
+      new WrappedRef(() => textArea.value, textArea.value = _)
   }
 }
 

--- a/dom/src/main/scala/fs2/dom/History.scala
+++ b/dom/src/main/scala/fs2/dom/History.scala
@@ -75,11 +75,10 @@ object History {
         def continuous = Stream.repeatEval(get)
       }
 
-      def scrollRestoration = new WrappedRef[F, ScrollRestoration] {
-        def unsafeGet(): ScrollRestoration = window.history.scrollRestoration
-        def unsafeSet(sr: ScrollRestoration): Unit =
-          window.history.scrollRestoration = sr
-      }
+      def scrollRestoration = new WrappedRef(
+        () => window.history.scrollRestoration,
+        window.history.scrollRestoration = _
+      )
 
       def forward = asyncPopState(window.history.forward())
       def back = asyncPopState(window.history.back())

--- a/dom/src/main/scala/fs2/dom/Location.scala
+++ b/dom/src/main/scala/fs2/dom/Location.scala
@@ -56,45 +56,21 @@ object Location {
   private def apply[F[_]](location: dom.Location)(implicit F: Sync[F]): Location[F] =
     new Location[F] {
 
-      def href = new WrappedRef[F, String] {
-        def unsafeGet() = location.href
-        def unsafeSet(s: String): Unit = location.href = s
-      }
+      def href = new WrappedRef(() => location.href, location.href = _)
 
-      def protocol = new WrappedRef[F, String] {
-        def unsafeGet() = location.protocol
-        def unsafeSet(s: String): Unit = location.protocol = s
-      }
+      def protocol = new WrappedRef(() => location.protocol, location.protocol = _)
 
-      def host = new WrappedRef[F, String] {
-        def unsafeGet() = location.host
-        def unsafeSet(s: String): Unit = location.host = s
-      }
+      def host = new WrappedRef(() => location.host, location.host = _)
 
-      def hostname = new WrappedRef[F, String] {
-        def unsafeGet() = location.hostname
-        def unsafeSet(s: String): Unit = location.hostname = s
-      }
+      def hostname = new WrappedRef(() => location.hostname, location.hostname = _)
 
-      def port = new WrappedRef[F, String] {
-        def unsafeGet() = location.port
-        def unsafeSet(s: String): Unit = location.port = s
-      }
+      def port = new WrappedRef(() => location.port, location.port = _)
 
-      def pathname = new WrappedRef[F, String] {
-        def unsafeGet() = location.pathname
-        def unsafeSet(s: String): Unit = location.pathname = s
-      }
+      def pathname = new WrappedRef(() => location.pathname, location.pathname = _)
 
-      def search = new WrappedRef[F, String] {
-        def unsafeGet() = location.search
-        def unsafeSet(s: String): Unit = location.search = s
-      }
+      def search = new WrappedRef(() => location.search, location.search = _)
 
-      def hash = new WrappedRef[F, String] {
-        def unsafeGet() = location.hash
-        def unsafeSet(s: String): Unit = location.hash = s
-      }
+      def hash = new WrappedRef(() => location.hash, location.hash = _)
 
       def origin = F.delay(location.origin.asInstanceOf[String])
 

--- a/dom/src/main/scala/fs2/dom/WrappedRef.scala
+++ b/dom/src/main/scala/fs2/dom/WrappedRef.scala
@@ -23,11 +23,11 @@ import cats.syntax.all._
 
 import scala.scalajs.js
 
-private[dom] abstract class WrappedRef[F[_], A](implicit F: Sync[F]) extends Ref[F, A] {
-
-  def unsafeGet(): A
-
-  def unsafeSet(a: A): Unit
+private final class WrappedRef[F[_], A](
+    unsafeGet: js.Function0[A],
+    unsafeSet: js.Function1[A, Unit]
+)(implicit F: Sync[F])
+    extends Ref[F, A] {
 
   def get: F[A] = F.delay(unsafeGet())
 

--- a/testsBrowser/src/test/scala/fs2/dom/HistorySuite.scala
+++ b/testsBrowser/src/test/scala/fs2/dom/HistorySuite.scala
@@ -19,13 +19,15 @@ package fs2.dom
 import cats.effect.IO
 import fs2.concurrent.Channel
 import munit.CatsEffectSuite
+import org.scalajs.dom.ScrollRestoration
 
 import scala.concurrent.duration._
 
 class HistorySuite extends CatsEffectSuite {
 
+  val history = History[IO, Int]
+
   test("history") {
-    val history = History[IO, Int]
     Channel.unbounded[IO, Int].flatMap { ch =>
       history.state.discrete.unNone.through(ch.sendAll).compile.drain.background.surround {
         for {
@@ -46,6 +48,10 @@ class HistorySuite extends CatsEffectSuite {
         } yield ()
       }
     }
+  }
+
+  test("scroll restoration") {
+    history.scrollRestoration.getAndUpdate(identity(_)).assertEquals(ScrollRestoration.auto)
   }
 
 }


### PR DESCRIPTION
A better alternative to https://github.com/armanbilge/fs2-dom/pull/49. I think.

The goal here is to avoid subclassing, because the proliferation of classes is bad for code size.