### PR TITLE
Remove circe dep, rework `Serializer`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -27,7 +27,6 @@ ThisBuild / githubWorkflowBuildPreamble +=
 
 val ceVersion = "3.4.6"
 val fs2Version = "3.6.1"
-val circeVersion = "0.14.3"
 val sjsDomVersion = "2.3.0"
 val munitCEVersion = "2.0.0-M3"
 val scalaCheckEffectVersion = "2.0.0-M2"
@@ -54,8 +53,7 @@ lazy val dom = project
     libraryDependencies ++= Seq(
       "org.typelevel" %%% "cats-effect" % ceVersion,
       "co.fs2" %%% "fs2-core" % fs2Version,
-      "org.scala-js" %%% "scalajs-dom" % sjsDomVersion,
-      "io.circe" %%% "circe-scalajs" % circeVersion
+      "org.scala-js" %%% "scalajs-dom" % sjsDomVersion
     )
   )
 

--- a/dom/src/main/scala/fs2/dom/PopStateEvent.scala
+++ b/dom/src/main/scala/fs2/dom/PopStateEvent.scala
@@ -21,7 +21,7 @@ import org.scalajs.dom
 
 abstract class PopStateEvent[F[_]] private[dom] extends Event[F] {
 
-  def state[F[_], S](implicit serializer: Serializer[F, S]): F[S]
+  def state[S: Serializer]: Either[Throwable, S]
 
 }
 
@@ -38,6 +38,5 @@ private trait PopStateEventImpl[F[_]] extends PopStateEvent[F] with EventImpl[F]
   def event: dom.PopStateEvent
   implicit def F: Sync[F]
 
-  def state[F[_], S](implicit serializer: Serializer[F, S]) =
-    serializer.deserialize(event.state)
+  def state[S](implicit serializer: Serializer[S]) = serializer.deserialize(event.state)
 }

--- a/dom/src/main/scala/fs2/dom/Serializer.scala
+++ b/dom/src/main/scala/fs2/dom/Serializer.scala
@@ -22,7 +22,7 @@ import scala.scalajs.js
 
 /** @see [[https://developer.mozilla.org/en-US/docs/Glossary/Serializable_object]]
   *
-  * @todo So far the only instance of [[Serializer]] is for [[Unit]].
+  * @todo So far the only instance of [[Serializer]] is for `Unit`.
   * Track progress in [[https://github.com/armanbilge/fs2-dom/issues/59 fs2-dom#59]]).
   */
 sealed abstract class Serializer[A] private {

--- a/dom/src/main/scala/fs2/dom/Serializer.scala
+++ b/dom/src/main/scala/fs2/dom/Serializer.scala
@@ -16,46 +16,37 @@
 
 package fs2.dom
 
-import cats.Invariant
-import cats.effect.kernel.Sync
 import cats.syntax.all._
-import io.circe.Decoder
-import io.circe.Encoder
-import io.circe.scalajs._
 
 import scala.scalajs.js
 
 /** @see [[https://developer.mozilla.org/en-US/docs/Glossary/Serializable_object]]
+  *
+  * @todo So far the only instance of [[Serializer]] is for [[Unit]].
+  * Track progress in [[https://github.com/armanbilge/fs2-dom/issues/59 fs2-dom#59]]).
   */
-trait Serializer[F[_], A] { outer =>
+sealed abstract class Serializer[A] private {
 
-  def serialize(a: A): F[js.Any]
+  def serialize(a: A): js.Any
 
-  def deserialize(serialized: js.Any): F[A]
-
-  final def imap[B](f: A => B)(g: B => A)(implicit F: Invariant[F]): Serializer[F, B] =
-    new Serializer[F, B] {
-      def serialize(b: B): F[js.Any] = outer.serialize(g(b))
-      def deserialize(serialized: js.Any): F[B] = outer.deserialize(serialized).imap(f)(g)
-    }
+  def deserialize(serialized: js.Any): Either[Throwable, A]
 
 }
 
 object Serializer {
 
-  implicit def invariant[F[_]: Invariant]: Invariant[Serializer[F, *]] =
-    new Invariant[Serializer[F, *]] {
-      def imap[A, B](fa: Serializer[F, A])(f: A => B)(g: B => A): Serializer[F, B] =
-        fa.imap(f)(g)
-    }
+  implicit def unit: Serializer[Unit] = new Serializer[Unit] {
+    def serialize(u: Unit): js.Any = u
+    def deserialize(serialized: js.Any): Either[Throwable, Unit] = Either.unit
+  }
 
-  implicit def fromCirceCodec[F[_], A](implicit
-      F: Sync[F],
-      decoder: Decoder[A],
-      encoder: Encoder[A]
-  ): Serializer[F, A] = new Serializer[F, A] {
-    def serialize(a: A): F[js.Any] = F.delay(a.asJsAny)
-    def deserialize(serialized: js.Any): F[A] = decodeJs[A](serialized).liftTo[F]
+  // used in test
+  private[dom] implicit def int: Serializer[Int] = new Serializer[Int] {
+    def serialize(i: Int): js.Any = i
+    def deserialize(serialized: js.Any): Either[Throwable, Int] = (serialized: Any) match {
+      case i: Int => Right(i)
+      case x      => Left(new NumberFormatException(x.toString))
+    }
   }
 
 }

--- a/dom/src/main/scala/fs2/dom/Window.scala
+++ b/dom/src/main/scala/fs2/dom/Window.scala
@@ -22,7 +22,7 @@ import org.scalajs.dom
 
 abstract class Window[F[_]] private extends WindowCrossCompat[F] {
 
-  def history[S](implicit serializer: Serializer[F, S]): History[F, S]
+  def history[S: Serializer]: History[F, S]
 
   def localStorage: Storage[F]
 
@@ -46,7 +46,7 @@ object Window {
 
       private[dom] def window = _window
 
-      def history[S](implicit serializer: Serializer[F, S]) = History(window, window.history)
+      def history[S: Serializer] = History(window, window.history)
 
       def localStorage = Storage(window.localStorage)
 


### PR DESCRIPTION
Fixes https://github.com/armanbilge/fs2-dom/issues/28. Closes https://github.com/armanbilge/fs2-dom/pull/57.

I don't have time to finish working on the new `Serializer` now, so I left enough in place to be minimally useful and so that it can be compatibly evolved as proposed in https://github.com/armanbilge/fs2-dom/issues/59. Anyway, use-cases are currently sparse.